### PR TITLE
fix: 新Nonebot适配 & refactor: 本地存储 & refactor: 异步并发

### DIFF
--- a/nonebot_plugin_fortune/__init__.py
+++ b/nonebot_plugin_fortune/__init__.py
@@ -23,7 +23,7 @@ from .data_source import FortuneManager, fortune_manager
 require("nonebot_plugin_apscheduler")
 from nonebot_plugin_apscheduler import scheduler  # isort:skip
 
-__fortune_version__ = "v0.4.12"
+__fortune_version__ = "v0.5.0"
 __fortune_usages__ = f"""
 [今日运势/抽签/运势] 一般抽签
 [xx抽签]     指定主题抽签

--- a/nonebot_plugin_fortune/__init__.py
+++ b/nonebot_plugin_fortune/__init__.py
@@ -1,6 +1,6 @@
-from typing import Annotated
 import base64
 from pathlib import Path
+from typing import Annotated
 
 from nonebot import on_command, on_fullmatch, on_regex, require
 from nonebot.adapters.onebot.v11 import (

--- a/nonebot_plugin_fortune/__init__.py
+++ b/nonebot_plugin_fortune/__init__.py
@@ -1,4 +1,6 @@
 from typing import Annotated
+import base64
+from pathlib import Path
 
 from nonebot import on_command, on_fullmatch, on_regex, require
 from nonebot.adapters.onebot.v11 import (
@@ -63,10 +65,32 @@ themes_list = on_fullmatch("主题列表", permission=GROUP, priority=8, block=T
 show_themes = on_regex("^查看(抽签)?主题$", permission=GROUP, priority=8, block=True)
 
 
+def _to_image_seg(image_file) -> MessageSegment:
+    """以 base64 形式发送，兼容读不到本地路径的协议端"""
+    file_path = Path(image_file).resolve()
+    img_b64 = base64.b64encode(file_path.read_bytes()).decode()
+    return MessageSegment.image(f"base64://{img_b64}")
+
+
+async def send_fortune(
+    matcher: Matcher, is_first: bool, image_file, gid: str, uid: str
+) -> None:
+    if image_file is None:
+        await matcher.finish("今日运势生成出错……")
+
+    if not is_first:
+        msg = MessageSegment.text("你今天抽过签了，再给你看一次哦🤗\n") + _to_image_seg(image_file)
+    else:
+        logger.info(f"User {uid} | Group {gid} 占卜了今日运势")
+        msg = MessageSegment.text("✨今日运势✨\n") + _to_image_seg(image_file)
+
+    await matcher.finish(msg, at_sender=True)
+
+
 @show_themes.handle()
 async def _(event: GroupMessageEvent):
     gid: str = str(event.group_id)
-    theme: str = fortune_manager.get_group_theme(gid)
+    theme: str = await fortune_manager.get_group_theme(gid)
     await show_themes.finish(f"当前群抽签主题：{FortuneThemesDict[theme][0]}")
 
 
@@ -86,19 +110,8 @@ async def _(event: GroupMessageEvent, args: Annotated[Message, CommandArg()]):
     gid: str = str(event.group_id)
     uid: str = str(event.user_id)
 
-    is_first, image_file = fortune_manager.divine(gid, uid, None, None)
-    if image_file is None:
-        await general_divine.finish("今日运势生成出错……")
-
-    if not is_first:
-        msg = MessageSegment.text("你今天抽过签了，再给你看一次哦🤗\n") + MessageSegment.image(
-            image_file
-        )
-    else:
-        logger.info(f"User {uid} | Group {gid} 占卜了今日运势")
-        msg = MessageSegment.text("✨今日运势✨\n") + MessageSegment.image(image_file)
-
-    await general_divine.finish(msg, at_sender=True)
+    is_first, image_file = await fortune_manager.divine(gid, uid, None, None)
+    await send_fortune(general_divine, is_first, image_file, gid, uid)
 
 
 @specific_divine.handle()
@@ -113,25 +126,12 @@ async def _(
         if user_theme in FortuneThemesDict[theme]:
             if not FortuneManager.theme_enable_check(theme):
                 await specific_divine.finish("该抽签主题未启用~")
-            else:
-                gid: str = str(event.group_id)
-                uid: str = str(event.user_id)
 
-                is_first, image_file = fortune_manager.divine(gid, uid, theme, None)
-                if image_file is None:
-                    await specific_divine.finish("今日运势生成出错……")
+            gid: str = str(event.group_id)
+            uid: str = str(event.user_id)
 
-                if not is_first:
-                    msg = MessageSegment.text(
-                        "你今天抽过签了，再给你看一次哦🤗\n"
-                    ) + MessageSegment.image(image_file)
-                else:
-                    logger.info(f"User {uid} | Group {gid} 占卜了今日运势")
-                    msg = MessageSegment.text("✨今日运势✨\n") + MessageSegment.image(
-                        image_file
-                    )
-
-            await specific_divine.finish(msg, at_sender=True)
+            is_first, image_file = await fortune_manager.divine(gid, uid, theme, None)
+            await send_fortune(specific_divine, is_first, image_file, gid, uid)
 
     await specific_divine.finish("还没有这种抽签主题哦~")
 
@@ -152,7 +152,7 @@ async def _(
 
     for theme in FortuneThemesDict:
         if user_theme in FortuneThemesDict[theme]:
-            if not fortune_manager.divination_setting(theme, gid):
+            if not await fortune_manager.divination_setting(theme, gid):
                 await change_theme.finish("该抽签主题未启用~")
             else:
                 await change_theme.finish("已设置当前群抽签主题~")
@@ -168,33 +168,21 @@ async def _(event: GroupMessageEvent, limit: Annotated[str, Depends(get_user_arg
     uid: str = str(event.user_id)
 
     if limit == "随机":
-        is_first, image_file = fortune_manager.divine(gid, uid, None, None)
-        if image_file is None:
-            await limit_setting.finish("今日运势生成出错……")
+        is_first, image_file = await fortune_manager.divine(gid, uid, None, None)
     else:
-        spec_path = fortune_manager.specific_check(limit)
+        spec_path = await fortune_manager.specific_check(limit)
         if not spec_path:
             await limit_setting.finish("还不可以指定这种签哦，请确认该签底对应主题开启或图片路径存在~")
-        else:
-            is_first, image_file = fortune_manager.divine(gid, uid, None, spec_path)
-            if image_file is None:
-                await limit_setting.finish("今日运势生成出错……")
 
-    if not is_first:
-        msg = MessageSegment.text("你今天抽过签了，再给你看一次哦🤗\n") + MessageSegment.image(
-            image_file
-        )
-    else:
-        logger.info(f"User {uid} | Group {gid} 占卜了今日运势")
-        msg = MessageSegment.text("✨今日运势✨\n") + MessageSegment.image(image_file)
+        is_first, image_file = await fortune_manager.divine(gid, uid, None, spec_path)
 
-    await limit_setting.finish(msg, at_sender=True)
+    await send_fortune(limit_setting, is_first, image_file, gid, uid)
 
 
 @reset_themes.handle()
 async def _(event: GroupMessageEvent):
     gid: str = str(event.group_id)
-    if not fortune_manager.divination_setting("random", gid):
+    if not await fortune_manager.divination_setting("random", gid):
         await reset_themes.finish("重置群抽签主题失败！")
 
     await reset_themes.finish("已重置当前群抽签主题为随机~")

--- a/nonebot_plugin_fortune/config.py
+++ b/nonebot_plugin_fortune/config.py
@@ -53,6 +53,7 @@ class ThemesFlagConfig(BaseModel):
     Switches of themes only valid in random divination.
     Make sure NOT ALL FALSE!
     """
+
     model_config = ConfigDict(extra="ignore")
 
     amazing_grace_flag: bool = True

--- a/nonebot_plugin_fortune/config.py
+++ b/nonebot_plugin_fortune/config.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Union
 
 from nonebot import get_driver
 from nonebot.log import logger
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .download import ResourceError, download_resource
 
@@ -40,15 +40,17 @@ FortuneThemesDict: Dict[str, List[str]] = {
 }
 
 
-class PluginConfig(BaseModel, extra=Extra.ignore):
+class PluginConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
     fortune_path: Path = Path(__file__).parent / "resource"
 
 
-class ThemesFlagConfig(BaseModel, extra=Extra.ignore):
+class ThemesFlagConfig(BaseModel):
     """
     Switches of themes only valid in random divination.
     Make sure NOT ALL FALSE!
     """
+    model_config = ConfigDict(extra="ignore")
 
     amazing_grace_flag: bool = True
     arknights_flag: bool = True
@@ -73,19 +75,19 @@ class ThemesFlagConfig(BaseModel, extra=Extra.ignore):
     touhou_old_flag: bool = True
     warship_girls_r_flag: bool = True
 
-    @root_validator
-    def check_all_disabled(cls, values) -> None:
+    @model_validator(mode="after")
+    def check_all_disabled(self) -> "ThemesFlagConfig":
         """Check whether all themes are DISABLED"""
         flag: bool = False
-        for theme in values:
-            if values.get(theme, False):
+        for key in self.__dict__:
+            if self.__dict__[key]:
                 flag = True
                 break
 
         if not flag:
             raise ValueError("Fortune themes ALL disabled! Please check!")
 
-        return values
+        return self
 
 
 class FortuneConfig(PluginConfig, ThemesFlagConfig):
@@ -103,8 +105,10 @@ class DateTimeEncoder(json.JSONEncoder):
 
 
 driver = get_driver()
-fortune_config: PluginConfig = PluginConfig.parse_obj(driver.config.dict())
-themes_flag_config: ThemesFlagConfig = ThemesFlagConfig.parse_obj(driver.config.dict())
+fortune_config: PluginConfig = PluginConfig.model_validate(driver.config.model_dump())
+themes_flag_config: ThemesFlagConfig = ThemesFlagConfig.model_validate(
+    driver.config.model_dump()
+)
 
 
 @driver.on_startup

--- a/nonebot_plugin_fortune/config.py
+++ b/nonebot_plugin_fortune/config.py
@@ -3,8 +3,11 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
-from nonebot import get_driver
+from nonebot import get_driver, require
 from nonebot.log import logger
+
+require("nonebot_plugin_localstore")
+import nonebot_plugin_localstore as store
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from .download import ResourceError, download_resource
@@ -111,6 +114,15 @@ themes_flag_config: ThemesFlagConfig = ThemesFlagConfig.model_validate(
 )
 
 
+# 运行时产物给 localstore 管理
+# 静态资源留在 resource 内
+_PLUGIN_NAME: str = "nonebot_plugin_fortune"
+USER_DATA_FILE: Path = store.get_data_file(_PLUGIN_NAME, "fortune_data.json")
+GROUP_RULES_FILE: Path = store.get_data_file(_PLUGIN_NAME, "group_rules.json")
+OUT_DIR: Path = store.get_cache_dir(_PLUGIN_NAME) / "out"
+SPECIFIC_RULES_FILE: Path = fortune_config.fortune_path / "specific_rules.json"
+
+
 @driver.on_startup
 async def fortune_check() -> None:
     if not fortune_config.fortune_path.exists():
@@ -143,10 +155,30 @@ async def fortune_check() -> None:
     """
 		Check rules and data files
 	"""
-    fortune_data_path: Path = fortune_config.fortune_path / "fortune_data.json"
+    fortune_data_path: Path = USER_DATA_FILE
+    group_rules_path: Path = GROUP_RULES_FILE
     fortune_setting_path: Path = fortune_config.fortune_path / "fortune_setting.json"
-    group_rules_path: Path = fortune_config.fortune_path / "group_rules.json"
-    specific_rules_path: Path = fortune_config.fortune_path / "specific_rules.json"
+    specific_rules_path: Path = SPECIFIC_RULES_FILE
+
+    USER_DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # 一次性迁移
+    for _legacy, _target in (
+        (fortune_config.fortune_path / "fortune_data.json", USER_DATA_FILE),
+        (fortune_config.fortune_path / "group_rules.json", GROUP_RULES_FILE),
+    ):
+        if _target.exists() or not _legacy.exists():
+            continue
+        try:
+            _content = json.loads(_legacy.read_text(encoding="utf-8"))
+        except Exception:
+            _content = {}
+        if _content:
+            _target.write_text(
+                json.dumps(_content, ensure_ascii=False, indent=4), encoding="utf-8"
+            )
+            logger.info(f"已将运行时数据迁移至 localstore 数据目录：{_target}")
 
     if not fortune_data_path.exists():
         logger.warning("Resource fortune_data.json is missing, initialized one...")

--- a/nonebot_plugin_fortune/config.py
+++ b/nonebot_plugin_fortune/config.py
@@ -148,9 +148,11 @@ async def fortune_check() -> None:
     if not copywriting_path.parent.exists():
         copywriting_path.parent.mkdir(parents=True, exist_ok=True)
 
-    ret = await download_resource(copywriting_path, "copywriting.json", "fortune")
-    if not ret and not copywriting_path.exists():
-        raise ResourceError("Resource copywriting.json is missing! Please check!")
+    # 本地已有文案则不再联网，避免每次启动都因镜像失效而卡住重试
+    if not copywriting_path.exists():
+        ret = await download_resource(copywriting_path, "copywriting.json", "fortune")
+        if not ret:
+            raise ResourceError("Resource copywriting.json is missing! Please check!")
 
     """
 		Check rules and data files

--- a/nonebot_plugin_fortune/data_source.py
+++ b/nonebot_plugin_fortune/data_source.py
@@ -1,8 +1,11 @@
+import asyncio
 import json
-import random
 from datetime import date, datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from random import choice
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from nonebot.log import logger
 
 from .config import (
     GROUP_RULES_FILE,
@@ -16,6 +19,12 @@ from .utils import drawing, theme_flag_check
 
 
 class FortuneManager:
+    """
+    抽签数据管理
+    首次访问时一次性载入内存，只在发生变更时落盘
+    涉及共享数据的操作都通过 ``_lock``串行，避免覆盖导致记录丢失
+    """
+
     def __init__(self):
         self._user_data: Dict[str, Dict[str, Dict[str, Union[str, int, date]]]] = dict()
         self._group_rules: Dict[str, str] = dict()
@@ -23,43 +32,41 @@ class FortuneManager:
         self._user_data_file: Path = USER_DATA_FILE
         self._group_rules_file: Path = GROUP_RULES_FILE
         self._specific_rules_file: Path = SPECIFIC_RULES_FILE
+        self._lock = asyncio.Lock()
+        self._loaded: bool = False
 
     def _multi_divine_check(self, gid: str, uid: str, nowtime: date) -> bool:
         """
-        检测是否重复抽签：判断此时与上次签到时间是否为同一天（年、月、日均相同）
+        检测是否重复抽签
         """
-        self._load_data()
+        last = self._user_data[gid][uid]["last_sign_date"]
 
-        # Means this is a new user
-        if isinstance(self._user_data[gid][uid]["last_sign_date"], int):
+        if isinstance(last, int):
             return False
 
-        last_sign_date: datetime = datetime.strptime(
-            # type: ignore
-            self._user_data[gid][uid]["last_sign_date"],
-            "%Y-%m-%d",
-        )
+        if isinstance(last, date):
+            last_sign_date: date = last
+        else:
+            last_sign_date = datetime.strptime(last, "%Y-%m-%d").date()
 
-        return last_sign_date.date() == nowtime
+        return last_sign_date == nowtime
 
-    def specific_check(self, charac: str) -> Optional[str]:
+    async def specific_check(self, charac: str) -> Optional[str]:
         """
-        检测是否有该签底规则
-        检查指定规则的签底所对应主题是否开启或路径是否存在
+        检测是否有该签底规则，并检查其所属主题是否开启
         """
-        self._load_specific_rules()
+        async with self._lock:
+            self._ensure_loaded()
+            paths = self._specific_rules.get(charac)
+            if not paths:
+                return None
 
-        if not self._specific_rules.get(charac, False):
-            return None
+            spec_path: str = choice(paths)
+            theme: str = Path(spec_path).parts[0]
+            return spec_path if theme_flag_check(theme) else None
 
-        spec_path: str = random.choice(self._specific_rules[charac])
-        for theme in FortuneThemesDict:
-            if theme in spec_path:
-                return spec_path if theme_flag_check(theme) else None
-
-        return None
-
-    def divine(
+    # 抽签主流程
+    async def divine(
         self,
         gid: str,
         uid: str,
@@ -70,60 +77,77 @@ class FortuneManager:
         今日运势抽签，主题已确认合法
         """
         now_time: date = date.today()
+        out_path: Path = OUT_DIR / f"{gid}_{uid}.png"
 
-        self._init_user_data(gid, uid)
-        self._load_group_rules()
+        async with self._lock:
+            self._ensure_loaded()
+            self._init_user_data(gid, uid)
 
-        if not isinstance(_theme, str):
-            theme: str = self._group_rules[gid]
-        else:
-            theme: str = _theme
+            theme: str = _theme if isinstance(_theme, str) else self._group_rules[gid]
+            already_divined: bool = self._multi_divine_check(gid, uid, now_time)
 
-        if not self._multi_divine_check(gid, uid, now_time):
-            try:
-                img_path = drawing(gid, uid, theme, spec_path)
-            except Exception:
+            if already_divined:
+                if out_path.exists():
+                    return False, out_path
+
+                img_path = await self._safe_draw(gid, uid, theme, spec_path)
+                return False, img_path
+
+            img_path = await self._safe_draw(gid, uid, theme, spec_path)
+            if img_path is None:
                 return True, None
 
-            # Record the sign-in time
-            self._end_data_handle(gid, uid, now_time)
+            # 绘制成功后记录签到时间
+            self._user_data[gid][uid]["last_sign_date"] = now_time
+            self._save_data()
             return True, img_path
-        else:
-            img_path: Path = OUT_DIR / f"{gid}_{uid}.png"
-            return False, img_path
 
     @staticmethod
     def clean_out_pics() -> None:
         """
-        Clean all the pictures saved at yesterday.
+        清空缓存目录下昨日生成的图片
         """
-        dirPath: Path = OUT_DIR
-        for pic in dirPath.iterdir():
+        if not OUT_DIR.exists():
+            return
+
+        for pic in OUT_DIR.iterdir():
             pic.unlink()
 
     def _init_user_data(self, gid: str, uid: str) -> None:
         """
-        初始化用户信息：
-        1. 群聊不在群组规则内，初始化
-        2. 群聊不在抽签数据内，初始化
-        3. 用户不在抽签数据内，初始化
+        确保群组与用户在内存数据中存在；新建的部分立即落盘。
+        调用前需持有 ``_lock`` 且数据已载入。
         """
-        self._load_data()
-        self._load_group_rules()
-
+        dirty_rules = False
         if gid not in self._group_rules:
-            self._group_rules.update({gid: "random"})
+            self._group_rules[gid] = "random"
+            dirty_rules = True
 
+        dirty_data = False
         if gid not in self._user_data:
             self._user_data[gid] = {}
+            dirty_data = True
 
         if uid not in self._user_data[gid]:
-            self._user_data[gid][uid] = {
-                "last_sign_date": 0  # Last sign-in date. YY-MM-DD
-            }
+            self._user_data[gid][uid] = {"last_sign_date": 0}
+            dirty_data = True
 
-        self._save_data()
-        self._save_group_rules()
+        if dirty_rules:
+            self._save_group_rules()
+        if dirty_data:
+            self._save_data()
+
+    async def _safe_draw(
+        self, gid: str, uid: str, theme: str, spec_path: Optional[str]
+    ) -> Optional[Path]:
+        """线程池绘图，失败时记录日志并返回 None"""
+        try:
+            return await asyncio.to_thread(drawing, gid, uid, theme, spec_path)
+        except Exception:
+            logger.exception(
+                f"绘制运势图失败 | Group {gid} | User {uid} | theme={theme} | spec={spec_path}"
+            )
+            return None
 
     @staticmethod
     def get_available_themes() -> str:
@@ -137,84 +161,68 @@ class FortuneManager:
 
         return msg
 
-    def _end_data_handle(self, gid: str, uid: str, nowtime: date) -> None:
-        """
-        占卜结束数据保存
-        """
-        self._load_data()
-
-        self._user_data[gid][uid]["last_sign_date"] = nowtime
-        self._save_data()
-
     @staticmethod
     def theme_enable_check(_theme: str) -> bool:
         """
-        Check whether a theme is enable
+        检查某主题是否启用
         """
         return _theme == "random" or theme_flag_check(_theme)
 
-    def divination_setting(self, theme: str, gid: str) -> bool:
+    async def divination_setting(self, theme: str, gid: str) -> bool:
         """
         分群管理抽签设置
         """
-        self._load_group_rules()
+        async with self._lock:
+            self._ensure_loaded()
+            if self.theme_enable_check(theme):
+                self._group_rules[gid] = theme
+                self._save_group_rules()
+                return True
 
-        if self.theme_enable_check(theme):
-            self._group_rules[gid] = theme
-            self._save_group_rules()
-            return True
+            return False
 
-        return False
-
-    def get_group_theme(self, gid: str) -> str:
+    async def get_group_theme(self, gid: str) -> str:
         """
         获取当前群抽签主题，若没有数据则初始化为随机
         """
-        self._load_group_rules()
+        async with self._lock:
+            self._ensure_loaded()
+            if gid not in self._group_rules:
+                self._group_rules[gid] = "random"
+                self._save_group_rules()
 
-        if gid not in self._group_rules:
-            self._group_rules.update({gid: "random"})
-            self._save_group_rules()
+            return self._group_rules[gid]
 
-        return self._group_rules[gid]
-
-    # ------------------------------ Utils ------------------------------ #
-    def _load_data(self) -> None:
+    # 内部数据操作
+    def _ensure_loaded(self) -> None:
         """
-        读取抽签数据
+        首次访问时把磁盘数据载入内存
+        需持有 _lock
         """
-        with open(self._user_data_file, "r", encoding="utf-8") as f:
-            self._user_data = json.load(f)
+        if self._loaded:
+            return
+
+        self._user_data = self._read_json(self._user_data_file)
+        self._group_rules = self._read_json(self._group_rules_file)
+        self._specific_rules = self._read_json(self._specific_rules_file)
+        self._loaded = True
+
+    @staticmethod
+    def _read_json(path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return dict()
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
 
     def _save_data(self) -> None:
-        """
-        保存抽签数据
-        """
         with open(self._user_data_file, "w", encoding="utf-8") as f:
             json.dump(
                 self._user_data, f, ensure_ascii=False, indent=4, cls=DateTimeEncoder
             )
 
-    def _load_group_rules(self) -> None:
-        """
-        读取各群抽签主题设置
-        """
-        with open(self._group_rules_file, "r", encoding="utf-8") as f:
-            self._group_rules = json.load(f)
-
     def _save_group_rules(self) -> None:
-        """
-        保存各群抽签主题设置
-        """
         with open(self._group_rules_file, "w", encoding="utf-8") as f:
             json.dump(self._group_rules, f, ensure_ascii=False, indent=4)
-
-    def _load_specific_rules(self) -> None:
-        """
-        读取签底指定规则 READ ONLY
-        """
-        with open(self._specific_rules_file, "r", encoding="utf-8") as f:
-            self._specific_rules = json.load(f)
 
 
 fortune_manager = FortuneManager()

--- a/nonebot_plugin_fortune/data_source.py
+++ b/nonebot_plugin_fortune/data_source.py
@@ -4,7 +4,14 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
-from .config import DateTimeEncoder, FortuneThemesDict, fortune_config
+from .config import (
+    GROUP_RULES_FILE,
+    OUT_DIR,
+    SPECIFIC_RULES_FILE,
+    USER_DATA_FILE,
+    DateTimeEncoder,
+    FortuneThemesDict,
+)
 from .utils import drawing, theme_flag_check
 
 
@@ -13,11 +20,9 @@ class FortuneManager:
         self._user_data: Dict[str, Dict[str, Dict[str, Union[str, int, date]]]] = dict()
         self._group_rules: Dict[str, str] = dict()
         self._specific_rules: Dict[str, List[str]] = dict()
-        self._user_data_file: Path = fortune_config.fortune_path / "fortune_data.json"
-        self._group_rules_file: Path = fortune_config.fortune_path / "group_rules.json"
-        self._specific_rules_file: Path = (
-            fortune_config.fortune_path / "specific_rules.json"
-        )
+        self._user_data_file: Path = USER_DATA_FILE
+        self._group_rules_file: Path = GROUP_RULES_FILE
+        self._specific_rules_file: Path = SPECIFIC_RULES_FILE
 
     def _multi_divine_check(self, gid: str, uid: str, nowtime: date) -> bool:
         """
@@ -84,7 +89,7 @@ class FortuneManager:
             self._end_data_handle(gid, uid, now_time)
             return True, img_path
         else:
-            img_path: Path = fortune_config.fortune_path / "out" / f"{gid}_{uid}.png"
+            img_path: Path = OUT_DIR / f"{gid}_{uid}.png"
             return False, img_path
 
     @staticmethod
@@ -92,7 +97,7 @@ class FortuneManager:
         """
         Clean all the pictures saved at yesterday.
         """
-        dirPath: Path = fortune_config.fortune_path / "out"
+        dirPath: Path = OUT_DIR
         for pic in dirPath.iterdir():
             pic.unlink()
 

--- a/nonebot_plugin_fortune/download.py
+++ b/nonebot_plugin_fortune/download.py
@@ -18,16 +18,16 @@ class ResourceError(Exception):
 
 async def download_url(url: str) -> Optional[Dict[str, Any]]:
     async with httpx.AsyncClient() as client:
-        for i in range(3):
+        for i in range(2):
             try:
-                resp = await client.get(url, timeout=20)
+                resp = await client.get(url, timeout=10)
                 if resp.status_code != 200:
                     continue
 
                 return resp.json()
 
             except Exception:
-                logger.warning(f"Error occurred when downloading {url}, retry: {i+1}/3")
+                logger.warning(f"Error occurred when downloading {url}, retry: {i+1}/2")
 
     logger.warning("Abort downloading")
     return None
@@ -40,7 +40,7 @@ async def download_resource(
     Try to download resources, json but not images.
     For fonts & copywriting, download and save into files when missing. Otherwise, raise ResourceError.
     """
-    base_url: str = "https://raw.fgit.ml/MinatoAquaCrews/nonebot_plugin_fortune/master/nonebot_plugin_fortune/resource"
+    base_url: str = "https://raw.githubusercontent.com/MinatoAquaCrews/nonebot_plugin_fortune/master/nonebot_plugin_fortune/resource"
 
     if isinstance(_type, str):
         url: str = base_url + "/" + _type + "/" + name

--- a/nonebot_plugin_fortune/utils.py
+++ b/nonebot_plugin_fortune/utils.py
@@ -68,11 +68,11 @@ def drawing(gid: str, uid: str, theme: str, spec_path: Optional[str] = None) -> 
         "text": f"{fortune_config.fortune_path}/font/sakura.ttf",
     }
     ttfront = ImageFont.truetype(fontPath["title"], font_size)
-    font_length = ttfront.getsize(title)
+    font_length = ttfront.getbbox(title)
     draw.text(
         (
-            image_font_center[0] - font_length[0] / 2,
-            image_font_center[1] - font_length[1] / 2,
+            image_font_center[0] - (font_length[2] - font_length[0]) / 2,
+            image_font_center[1] - (font_length[3] - font_length[1]) / 2,
         ),
         title,
         fill=color,
@@ -158,4 +158,4 @@ def theme_flag_check(theme: str) -> bool:
     """
     check wether a theme is enabled in themes_flag_config
     """
-    return themes_flag_config.dict().get(theme + "_flag", False)
+    return themes_flag_config.model_dump().get(theme + "_flag", False)

--- a/nonebot_plugin_fortune/utils.py
+++ b/nonebot_plugin_fortune/utils.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple
 
 from PIL import Image, ImageDraw, ImageFont
 
-from .config import fortune_config, themes_flag_config
+from .config import OUT_DIR, fortune_config, themes_flag_config
 
 
 def get_copywriting() -> Tuple[str, str]:
@@ -99,11 +99,10 @@ def drawing(gid: str, uid: str, theme: str, spec_path: Optional[str] = None) -> 
         draw.text((x, y), textVertical, fill=color, font=ttfront)
 
     # Save
-    outDir: Path = fortune_config.fortune_path / "out"
-    if not outDir.exists():
-        outDir.mkdir(exist_ok=True, parents=True)
+    if not OUT_DIR.exists():
+        OUT_DIR.mkdir(exist_ok=True, parents=True)
 
-    outPath = outDir / f"{gid}_{uid}.png"
+    outPath = OUT_DIR / f"{gid}_{uid}.png"
 
     img.save(outPath)
     return outPath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nonebot_plugin_fortune"
-version = "0.4.12"
+version = "0.5.0"
 description = "Fortune divination!"
 authors = ["KafCoppelia <k740677208@gmail.com>"]
 license = "MIT"
@@ -17,7 +17,8 @@ python = "^3.9"
 nonebot2 = "^2.0.0rc4"
 nonebot-adapter-onebot = "^2.2.0"
 nonebot-plugin-apscheduler = "^0.2.0"
-pillow = "^9.0.0"
+nonebot-plugin-localstore = "^0.7.0"
+pillow = ">=9.0.0"
 httpx = "^0.23.0"
 aiofiles = "^0.8.0"
 


### PR DESCRIPTION
## 改动内容

- 由于 Pydantic 版本限制在新 Nonebot 环境下已经无法运行，进行一些小修改适配 Pillow 10+ & Pydantic v2
- 数据层并发安全重构
- 存储位置调整到bot根目录的`data`和`cache`文件夹，不再生成在插件内

## 详细说明

- 借助`nonebot-plugin-localstore`把运行时产物移出插件目录
- 启动时一次性迁移，把 `resource/` 内数据搬到数据目录
- 资源镜像 `raw.fgit.ml` 已失效，换回 `raw.githubusercontent.com`。
- 降低下载超时和重试次数
- 数据首次访问载入内存，只在变更时落盘，提高文件读写效率
- `asyncio.Lock` 串行化
- 绘图移入 `asyncio.to_thread`，避免阻塞事件循环
- 抽出统一 `send_fortune`发送，一致改用 base64

### 版本号 & 依赖 & 兼容
- 版本从`0.4.12`调整到`0.5.0`，没加tag
- 新增依赖 `nonebot-plugin-localstore`
- `pillow` 从`^9.0.0`调整到`>=9.0.0`
- 旧数据在启动时自动迁移，无需手动操作

## 测试

- 本地 OneBot V11 实测运行正常
- 冒烟测试覆盖（AI执行）：20 个并发运行正常
- 每项commit实测可以单独运行